### PR TITLE
Remove redundant directive in modules and fix JSDoc comments

### DIFF
--- a/app/templates/project-name.Website/Scripts/Shared/cookieconsent/index.js
+++ b/app/templates/project-name.Website/Scripts/Shared/cookieconsent/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import $ from 'jquery';
 import 'kv.cookieconsent';
 

--- a/app/templates/project-name.Website/Scripts/Shared/helpers/helper.isTouchDevice.js
+++ b/app/templates/project-name.Website/Scripts/Shared/helpers/helper.isTouchDevice.js
@@ -1,8 +1,7 @@
-'use strict';
-
 /**
  * Determines whether the current device supports touch events
- * @return {Boolean} [description]
+ *
+ * @return {boolean}
  */
 export default function isTouchDevice() {
     return (('ontouchstart' in window) || (navigator.MaxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0));

--- a/app/templates/project-name.Website/Scripts/Shared/helpers/helper.loader.js
+++ b/app/templates/project-name.Website/Scripts/Shared/helpers/helper.loader.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import $ from 'jquery';
 
 let instance = null;

--- a/app/templates/project-name.Website/Scripts/Shared/helpers/helper.print.js
+++ b/app/templates/project-name.Website/Scripts/Shared/helpers/helper.print.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import $ from 'jquery';
 
 export default function printPage(){

--- a/app/templates/project-name.Website/Scripts/Shared/helpers/helper.scrollToElm.js
+++ b/app/templates/project-name.Website/Scripts/Shared/helpers/helper.scrollToElm.js
@@ -1,12 +1,11 @@
-'use strict';
-
 import $ from 'jquery';
 
 /**
- * [scrollToElm description]
- * @param  {[string]} selector [css selector]
- * @param  {[number]} speed    [speed in ms]
- * @return {[undefined]}       [nothing returned]
+ * Scroll page to a specific element
+ *
+ * @param {string} selector    CSS selector
+ * @param {number} speed       Speed in ms
+ * @param {number} scrollNudge
  */
 export default function scrollToElm(selector, speed = 500, scrollNudge = 74) {
     if (!selector){

--- a/app/templates/project-name.Website/Scripts/Shared/helpers/helper.windowOpen.js
+++ b/app/templates/project-name.Website/Scripts/Shared/helpers/helper.windowOpen.js
@@ -1,12 +1,11 @@
-'use strict';
-
 import $ from 'jquery';
 
 export default function windowOpen() {
     $('.js-helper-window-open').on('click', function(e){
-        const url = $(this).attr('href');
-        const name = $(this).attr('target');
-        const specs = $(this).data('specs');
+        const elm = $(this);
+        const url = elm.attr('href');
+        const name = elm.attr('target');
+        const specs = elm.data('specs');
 
         window.open(url, name, specs || 'width=600, height=300, titlebar=0, menubar=0, status=0');
         e.preventDefault();

--- a/app/templates/project-name.Website/Scripts/Shared/helpers/index.js
+++ b/app/templates/project-name.Website/Scripts/Shared/helpers/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import printPage                 from './helper.print';
 import windowOpen                from './helper.windowOpen';
 import scrollToElement           from './helper.scrollToElm';

--- a/app/templates/project-name.Website/Scripts/Shared/lightbox/index.js
+++ b/app/templates/project-name.Website/Scripts/Shared/lightbox/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import normal       from './lightbox.default';
 import iframe       from './lightbox.iframe';
 import video        from './lightbox.video';

--- a/app/templates/project-name.Website/Scripts/Shared/lightbox/lightbox.default.js
+++ b/app/templates/project-name.Website/Scripts/Shared/lightbox/lightbox.default.js
@@ -1,12 +1,10 @@
-'use strict';
-
 import $ from 'jquery';
 import '@fancyapps/fancybox';
 
 /**
- * [defaultLightbox]
- * @param  {[string]}   scope   [css selector]
- * @return {[undefined]}        [nothing returned]
+ * Init default Lightbox
+ *
+ * @param {string} scope CSS selector
  */
 export default function defaultLightbox(scope){
     $(scope).each(function () {

--- a/app/templates/project-name.Website/Scripts/Shared/lightbox/lightbox.iframe.js
+++ b/app/templates/project-name.Website/Scripts/Shared/lightbox/lightbox.iframe.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import $ from 'jquery';
 import '@fancyapps/fancybox';
 

--- a/app/templates/project-name.Website/Scripts/Shared/lightbox/lightbox.video.js
+++ b/app/templates/project-name.Website/Scripts/Shared/lightbox/lightbox.video.js
@@ -1,12 +1,10 @@
-'use strict';
-
 import $ from 'jquery';
 import '@fancyapps/fancybox';
 
 /**
- * [videoLightbox description]
- * @param  {[type]} scope [description]
- * @return {[type]}       [description]
+ * Init video Lightbox
+ *
+ * @param {string} scope CSS selector
  */
 export default function videoLightbox(scope){
     $(scope).each(function () {


### PR DESCRIPTION
Just minor stuff: (1) "use strict" directive removed since modules are always strict and webpack makes sure it's true (2) some JSDoc comments were updated, so we have a better IntelliSense experience.