### PR TITLE
fix scaffold command in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install -g yo @kraftvaerk/generator-rammevaerk
 To scaffold a new project run:
 
 ```
-yo @kraftvaerk/generator-rammevaerk
+yo @kraftvaerk/rammevaerk
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
While trying to scaffold a new project by following readme steps I noticed that `yo @kraftvaerk/generator-rammevaerk` isn't a correct command to run globally installed generator.
The correct command is `yo @kraftvaerk/rammevaerk`.

![image](https://user-images.githubusercontent.com/9119663/68758626-3586c900-061f-11ea-8666-1814be56de72.png)

![image](https://user-images.githubusercontent.com/9119663/68758592-299b0700-061f-11ea-836e-f84e73a9b25d.png)
